### PR TITLE
Fix invalid regex.

### DIFF
--- a/src/latexoutputfilter.cpp
+++ b/src/latexoutputfilter.cpp
@@ -616,7 +616,7 @@ bool LatexOutputFilter::detectBadBoxLineNumber(string & strLine, short & dwCooki
 	static Regex reBadBoxLine("(.*) at line ([0-9]+)", true);
 	//Use the following only, if you know how to get the source line for it.
 	// This is not simple, as TeX is not reporting it.
-	static Regex reBadBoxOutput("(.*)has occurred while \\output is active^", true);
+	static Regex reBadBoxOutput("(.*)has occurred while \\\\output is active^", true);
 
 	string match = strLine;
 


### PR DESCRIPTION
In order to match \output, two escaped backslashes need to be there, or the following error (which halts parsing) is triggered:
    Error parsing regex (.*)has occurred while \output is active^, pattern error at offset 24