### PR TITLE
SConstruct: make sure 'luatex' is always defined

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -34,7 +34,7 @@ if env['PLATFORM'] == 'posix':
     luatex = env.FileCopy("bin/ppluatex", "src/ppluatex")
 else:
     # Otherwise, we just copy the binary again.
-    pdftex = env.FileCopy("bin/ppluatex"+env['PROGSUFFIX'], app)
+    luatex = env.FileCopy("bin/ppluatex"+env['PROGSUFFIX'], app)
 
 
 # For testing, run the .tex files in test/ through pplatex inside a temp directory


### PR DESCRIPTION
I know little about scons so this could be incorrect, but without this change I get the following build error on Mac OS 10.10.4:
```
scons: Reading SConscript files ...
NameError: name 'luatex' is not defined:
  File "/private/tmp/pplatex20150803-66818-1if5ltz/pplatex-pplatex-1.0-rc2/SConstruct", line 46:
    Alias('app', [pdftex,luatex] )
```