### PR TITLE
Fix SCons build

### DIFF
--- a/site_scons/conf/CUDASetup.py
+++ b/site_scons/conf/CUDASetup.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import platform
 import SCons
@@ -16,43 +17,43 @@ def SetupEnv(env, optional=False, cutil=False):
 
     # find CUDA Toolkit path and set CUDA_TOOLKIT_PATH
     try:
-	cudaToolkitPath = env['CUDA_TOOLKIT_PATH']
+        cudaToolkitPath = env['CUDA_TOOLKIT_PATH']
     except:
-	cudaToolkitPath = None
+        cudaToolkitPath = None
     if cudaToolkitPath == None:
-	cudaToolkitPath == FindCudaToolkit()
-	env['CUDA_TOOLKIT_PATH'] = cudaToolkitPath
+        cudaToolkitPath == FindCudaToolkit()
+        env['CUDA_TOOLKIT_PATH'] = cudaToolkitPath
     if cudaToolkitPath == None:
-	print "scons: Cannot find the CUDA Toolkit path. Please set env['CUDA_TOOLKIT_PATH'] to point to your Toolkit path"
-	return
+        print("scons: Cannot find the CUDA Toolkit path. Please set env['CUDA_TOOLKIT_PATH'] to point to your Toolkit path")
+        return
 
     # find CUDA SDK path and set CUDA_SDK_PATH
     try:
-	cudaSDKPath = env['CUDA_SDK_PATH']
+        cudaSDKPath = env['CUDA_SDK_PATH']
     except:
-	cudaSDKPath = None
+        cudaSDKPath = None
     if cudaSDKPath == None:
-	cudaSDKPath = FindCudaSDK()
-	env['CUDA_SDK_PATH'] = cudaSDKPath
+        cudaSDKPath = FindCudaSDK()
+        env['CUDA_SDK_PATH'] = cudaSDKPath
     if cudaSDKPath == None and not optional:
-	print "scons: Cannot find the CUDA SDK path. Please set env['CUDA_SDK_PATH'] to point to your SDK path."
-	return
+        print("scons: Cannot find the CUDA SDK path. Please set env['CUDA_SDK_PATH'] to point to your SDK path.")
+        return
 
     # cuda libraries
     if env['PLATFORM'] == 'posix':
-	cudaSDKSubLibDir = '/linux'
+        cudaSDKSubLibDir = '/linux'
     elif env['PLATFORM'] == 'darwin':
-	cudaSDKSubLibDir = '/darwin'
+        cudaSDKSubLibDir = '/darwin'
     else:
-	cudaSDKSubLibDir = ''
+        cudaSDKSubLibDir = ''
     cudaSDKLibDir = '/lib'
 
     if os.path.exists(cudaToolkitPath + '/bin64'):
-	cudaLibDir = '/lib64'
-	cudaBinDir = '/bin64'
+        cudaLibDir = '/lib64'
+        cudaBinDir = '/bin64'
     else:
-	cudaLibDir = '/lib'
-	cudaBinDir = '/bin'
+        cudaLibDir = '/lib'
+        cudaBinDir = '/bin'
 
     # add nvcc to PATH, setup Toolkit
     env.PrependENVPath('PATH', cudaToolkitPath + cudaBinDir)
@@ -65,9 +66,9 @@ def SetupEnv(env, optional=False, cutil=False):
 
     release = env.get('RELEASE',None)
     if release == 'debug':
-	env.AppendUnique(NVCCFLAGS=['-g'])
+        env.AppendUnique(NVCCFLAGS=['-g'])
     if release == 'release':
-	env.AppendUnique(NVCCFLAGS=['-O'])
+        env.AppendUnique(NVCCFLAGS=['-O'])
 
     # add required libraries
     env.AppendUnique(CPPPATH=[cudaToolkitPath + '/include'])
@@ -75,15 +76,15 @@ def SetupEnv(env, optional=False, cutil=False):
     env.AppendUnique(LIBS=['cudart'])
 
     if cudaSDKPath is not None:
-	cudaSDKPath += '/C'
-	env.AppendUnique(CPPPATH=[cudaSDKPath + '/common/inc'])
-	env.AppendUnique(LIBPATH=[cudaSDKPath + cudaSDKLibDir, cudaSDKPath + '/common/'+cudaSDKLibDir + cudaSDKSubLibDir])
-	if cutil:
-	    if env['PLATFORM'] == 'win32':
-		bits = GetArchBits(env)
-		env.AppendUnique(LIBS=['cutil'+bits])
-	    else:
-		env.AppendUnique(LIBS=['cutil'])
+        cudaSDKPath += '/C'
+        env.AppendUnique(CPPPATH=[cudaSDKPath + '/common/inc'])
+        env.AppendUnique(LIBPATH=[cudaSDKPath + cudaSDKLibDir, cudaSDKPath + '/common/'+cudaSDKLibDir + cudaSDKSubLibDir])
+        if cutil:
+            if env['PLATFORM'] == 'win32':
+                bits = GetArchBits(env)
+                env.AppendUnique(LIBS=['cutil'+bits])
+            else:
+                env.AppendUnique(LIBS=['cutil'])
 
 
 # Helper functions
@@ -94,39 +95,39 @@ def FindCudaToolkit():
     homedrive=os.environ.get('HOMEDRIVE', '')
 
     paths=[ home + '/NVIDIA_CUDA_TOOLKIT',
-	    home + '/Apps/NVIDIA_CUDA_TOOLKIT',
-	    home + '/Apps/NVIDIA_CUDA_TOOLKIT',
-	    home + '/Apps/CudaToolkit',
-	    home + '/Apps/CudaTK',
-	    '/usr/local/NVIDIA_CUDA_TOOLKIT',
-	    '/usr/local/CUDA_TOOLKIT',
-	    '/usr/local/cuda_toolkit',
-	    '/usr/local/CUDA',
-	    '/usr/local/cuda',
-	    '/Developer/NVIDIA CUDA TOOLKIT',
-	    '/Developer/CUDA TOOLKIT',
-	    '/Developer/CUDA',
-	    '/opt/nvidia/cuda/toolkit',
-	    '/opt/NVIDIA/CUDA/Toolkit',
-	    '/opt/nvidia/cuda toolkit',
-	    '/opt/NVIDIA/CUDA Toolkit',
-	    programfiles + 'NVIDIA Corporation/NVIDIA CUDA TOOLKIT',
-	    programfiles + 'NVIDIA Corporation/NVIDIA CUDA',
-	    programfiles + 'NVIDIA Corporation/CUDA TOOLKIT',
-	    programfiles + 'NVIDIA Corporation/CUDA',
-	    programfiles + 'NVIDIA/NVIDIA CUDA TOOLKIT',
-	    programfiles + 'NVIDIA/NVIDIA CUDA',
-	    programfiles + 'NVIDIA/CUDA TOOLKIT',
-	    programfiles + 'NVIDIA/CUDA',
-	    programfiles + 'CUDA TOOLKIT',
-	    programfiles + 'CUDA',
-	    homedrive + '/CUDA TOOLKIT',
-	    homedrive + '/CUDA']
+            home + '/Apps/NVIDIA_CUDA_TOOLKIT',
+            home + '/Apps/NVIDIA_CUDA_TOOLKIT',
+            home + '/Apps/CudaToolkit',
+            home + '/Apps/CudaTK',
+            '/usr/local/NVIDIA_CUDA_TOOLKIT',
+            '/usr/local/CUDA_TOOLKIT',
+            '/usr/local/cuda_toolkit',
+            '/usr/local/CUDA',
+            '/usr/local/cuda',
+            '/Developer/NVIDIA CUDA TOOLKIT',
+            '/Developer/CUDA TOOLKIT',
+            '/Developer/CUDA',
+            '/opt/nvidia/cuda/toolkit',
+            '/opt/NVIDIA/CUDA/Toolkit',
+            '/opt/nvidia/cuda toolkit',
+            '/opt/NVIDIA/CUDA Toolkit',
+            programfiles + 'NVIDIA Corporation/NVIDIA CUDA TOOLKIT',
+            programfiles + 'NVIDIA Corporation/NVIDIA CUDA',
+            programfiles + 'NVIDIA Corporation/CUDA TOOLKIT',
+            programfiles + 'NVIDIA Corporation/CUDA',
+            programfiles + 'NVIDIA/NVIDIA CUDA TOOLKIT',
+            programfiles + 'NVIDIA/NVIDIA CUDA',
+            programfiles + 'NVIDIA/CUDA TOOLKIT',
+            programfiles + 'NVIDIA/CUDA',
+            programfiles + 'CUDA TOOLKIT',
+            programfiles + 'CUDA',
+            homedrive + '/CUDA TOOLKIT',
+            homedrive + '/CUDA']
 
     for path in paths:
-	if os.path.isdir(path):
-	    print 'scons: CUDA Toolkit found in ' + path
-	    return path
+        if os.path.isdir(path):
+            print('scons: CUDA Toolkit found in ' + path)
+            return path
     
     return None
 
@@ -136,29 +137,29 @@ def FindCudaSDK():
     homedrive=os.environ.get('HOMEDRIVE', '')
 
     paths=[ home + '/NVIDIA_CUDA_SDK', # i am just guessing here
-	    home + '/Apps/NVIDIA_CUDA_SDK',
-	    home + '/Apps/CudaSDK',
-	    '/usr/local/NVIDIA_CUDA_SDK',
-	    '/usr/local/CUDASDK',
-	    '/usr/local/cuda_sdk',
-	    '/Developer/NVIDIA CUDA SDK',
-	    '/Developer/CUDA SDK',
-	    '/Developer/CUDA',
-	    '/opt/nvidia/cuda/sdk',
-	    '/opt/NVIDIA/CUDA/SDK',
-	    '/opt/nvidia/cuda sdk',
-	    '/opt/NVIDIA/CUDA SDK',
-	    programfiles + 'NVIDIA Corporation/NVIDIA CUDA SDK',
-	    programfiles + 'NVIDIA/NVIDIA CUDA SDK',
-	    programfiles + 'NVIDIA CUDA SDK',
-	    programfiles + 'CudaSDK',
-	    homedrive + '/NVIDIA CUDA SDK',
-	    homedrive + '/CUDA SDK',
-	    homedrive + '/CUDA/SDK']
+            home + '/Apps/NVIDIA_CUDA_SDK',
+            home + '/Apps/CudaSDK',
+            '/usr/local/NVIDIA_CUDA_SDK',
+            '/usr/local/CUDASDK',
+            '/usr/local/cuda_sdk',
+            '/Developer/NVIDIA CUDA SDK',
+            '/Developer/CUDA SDK',
+            '/Developer/CUDA',
+            '/opt/nvidia/cuda/sdk',
+            '/opt/NVIDIA/CUDA/SDK',
+            '/opt/nvidia/cuda sdk',
+            '/opt/NVIDIA/CUDA SDK',
+            programfiles + 'NVIDIA Corporation/NVIDIA CUDA SDK',
+            programfiles + 'NVIDIA/NVIDIA CUDA SDK',
+            programfiles + 'NVIDIA CUDA SDK',
+            programfiles + 'CudaSDK',
+            homedrive + '/NVIDIA CUDA SDK',
+            homedrive + '/CUDA SDK',
+            homedrive + '/CUDA/SDK']
     for path in paths:
-	if os.path.isdir(path):
-	    print 'scons: CUDA SDK found in ' + path
-	    return path
+        if os.path.isdir(path):
+            print('scons: CUDA SDK found in ' + path)
+            return path
 
     return None
 

--- a/site_scons/conf/CppSetup.py
+++ b/site_scons/conf/CppSetup.py
@@ -1,11 +1,11 @@
 import os
 import platform
-import MSVCSetup
+from . import MSVCSetup
 from envhelper import *
 
 def AddVariables(vars):
     if platform.system() == "Windows":
-	MSVCSetup.AddVariables(vars)
+        MSVCSetup.AddVariables(vars)
 
 def SetupFlags(env, addReleaseVars=True):
     """Setup various common C++ defines, such as compiler, platform, release, ...
@@ -13,34 +13,34 @@ def SetupFlags(env, addReleaseVars=True):
     # TODO use Configure here, create config.h file?
 
     if env['PLATFORM'] == "win32":
-	env.AppendUnique( CPPDEFINES=['_WIN32'] )
+        env.AppendUnique( CPPDEFINES=['_WIN32'] )
 
     if addReleaseVars:
-	release = env.get('RELEASE',None)
-	if release is not None:
-	    env.AppendUnique( CPPDEFINES=[('RELEASE',release)] )
+        release = env.get('RELEASE',None)
+        if release is not None:
+            env.AppendUnique( CPPDEFINES=[('RELEASE',release)] )
 
-	name = env.get('RELEASE_NAME', None)
-	version = env.get('RELEASE_VERSION', None)
+        name = env.get('RELEASE_NAME', None)
+        version = env.get('RELEASE_VERSION', None)
 
-	if name is not None:
-	    env.AppendUnique( CPPDEFINES=[('RELEASE_NAME', name)] )
-	if version is not None:
-	    env.AppendUnique( CPPDEFINES=[('RELEASE_VERSION', version)] )
+        if name is not None:
+            env.AppendUnique( CPPDEFINES=[('RELEASE_NAME', name)] )
+        if version is not None:
+            env.AppendUnique( CPPDEFINES=[('RELEASE_VERSION', version)] )
 
 
 def SetupEnv(env, runtime="default", console=False, exceptions=True, omitFP=True, manifestDir=None, pdb=None, addReleaseVars=True):
     """Setup the C++ compiler environment.
        Parameters:
-       - runtime	Runtime version to use: one of 'default', 'mt', 'mt-lib' 
-	                (Default, Multithreaded, statically linked, Multithreaded, shared lib)
-       - console	Compile as console application
-       - exceptions	Use C++ exceptions
-       - omitFP		Omit frame pointers
+       - runtime        Runtime version to use: one of 'default', 'mt', 'mt-lib' 
+                        (Default, Multithreaded, statically linked, Multithreaded, shared lib)
+       - console        Compile as console application
+       - exceptions        Use C++ exceptions
+       - omitFP                Omit frame pointers
        - manifestDir    Directory to store manifest files. If set, manifests will be created and added
-			to programs and libraries. 
-       - pdb		Name of pdb file. Will be generated in debug mode if set.
-       - addReleaseVars	Add RELEASE, RELEASE_NAME and RELEASE_VERSION as defines from env.
+                        to programs and libraries. 
+       - pdb                Name of pdb file. Will be generated in debug mode if set.
+       - addReleaseVars        Add RELEASE, RELEASE_NAME and RELEASE_VERSION as defines from env.
     """
 
     # TODO not not call setupflags if it has already been set for env
@@ -49,61 +49,61 @@ def SetupEnv(env, runtime="default", console=False, exceptions=True, omitFP=True
     release = env.get('RELEASE',None)
 
     if env['CC'] == 'cl':
-	MSVCSetup.SetupEnv(env)
+        MSVCSetup.SetupEnv(env)
 
-	def IgnoreLibs(env, libs):
-	    env.AppendUnique( LINKFLAGS=[ '/NODEFAULTLIB:'+lib+'.lib' for lib in libs ] )
+        def IgnoreLibs(env, libs):
+            env.AppendUnique( LINKFLAGS=[ '/NODEFAULTLIB:'+lib+'.lib' for lib in libs ] )
 
-	if release == 'debug':
-	    env.AppendUnique( CPPFLAGS=['/W4', '/Z7', '/Od'])
+        if release == 'debug':
+            env.AppendUnique( CPPFLAGS=['/W4', '/Z7', '/Od'])
 
-	    env.AppendUnique( LINKFLAGS=['/DEBUG'] )
+            env.AppendUnique( LINKFLAGS=['/DEBUG'] )
 
-	    if runtime == 'mt-lib':
-		env.AppendUnique( CPPFLAGS=['/MDd'] )
-		IgnoreLibs(env, ['libc', 'libcmt', 'msvcrt', 'libcd', 'libcmtd' ] )
-	    elif runtime == 'mt':
-		env.AppendUnique( CPPFLAGS=['/MTd'] )
-		IgnoreLibs(env, ['libc', 'libcmt', 'msvcrt', 'libcd', 'msvcrtd' ] )
+            if runtime == 'mt-lib':
+                env.AppendUnique( CPPFLAGS=['/MDd'] )
+                IgnoreLibs(env, ['libc', 'libcmt', 'msvcrt', 'libcd', 'libcmtd' ] )
+            elif runtime == 'mt':
+                env.AppendUnique( CPPFLAGS=['/MTd'] )
+                IgnoreLibs(env, ['libc', 'libcmt', 'msvcrt', 'libcd', 'msvcrtd' ] )
 
-	    if pdb is not None:
-		env['PDB'] = pdb
+            if pdb is not None:
+                env['PDB'] = pdb
 
-	# end Debug flags
+        # end Debug flags
 
-	if release == 'release':
-	    env.AppendUnique( CPPFLAGS=['/W3', '/O2', '/Oi', '/GL'] )
+        if release == 'release':
+            env.AppendUnique( CPPFLAGS=['/W3', '/O2', '/Oi', '/GL'] )
 
-	    env.AppendUnique( LINKFLAGS=['/INCREMENTAL:NO', '/LTCG'] )
+            env.AppendUnique( LINKFLAGS=['/INCREMENTAL:NO', '/LTCG'] )
 
-	    if omitFP:
-		env.AppendUnique( CPPFLAGS=['/Oy'] )
+            if omitFP:
+                env.AppendUnique( CPPFLAGS=['/Oy'] )
 
-	    if runtime == 'mt-lib':
-		env.AppendUnique( CPPFLAGS=['/MD'] )
-		IgnoreLibs(env, ['libc', 'libcmt', 'msvcrtd', 'libcd', 'libcmtd' ] )
-	    elif runtime == 'mt':
-		env.AppendUnique( CPPFLAGS=['/MT'] )
-		IgnoreLibs(env, ['libc', 'msvcrt', 'msvcrtd', 'libcd', 'libcmtd' ] )
+            if runtime == 'mt-lib':
+                env.AppendUnique( CPPFLAGS=['/MD'] )
+                IgnoreLibs(env, ['libc', 'libcmt', 'msvcrtd', 'libcd', 'libcmtd' ] )
+            elif runtime == 'mt':
+                env.AppendUnique( CPPFLAGS=['/MT'] )
+                IgnoreLibs(env, ['libc', 'msvcrt', 'msvcrtd', 'libcd', 'libcmtd' ] )
 
-	# end Release flags
-	
-	if exceptions:
-	    env.AppendUnique( CPPFLAGS=['/EHsc'] )
-	
-	env.AppendUnique( CPPFLAGS=['/nologo'] )
+        # end Release flags
+        
+        if exceptions:
+            env.AppendUnique( CPPFLAGS=['/EHsc'] )
+        
+        env.AppendUnique( CPPFLAGS=['/nologo'] )
 
-	if console:
-	    env.AppendUnique( CPPDEFINES=['_CONSOLE'] )
-	    env.AppendUnique( LINKFLAGS=['/SUBSYSTEM:CONSOLE'] )
-	
+        if console:
+            env.AppendUnique( CPPDEFINES=['_CONSOLE'] )
+            env.AppendUnique( LINKFLAGS=['/SUBSYSTEM:CONSOLE'] )
+        
 
-	if manifestDir is not None:
-	    # TODO add manifest as sideeffect() and clean() using an emitter 
-	    manifestfile = os.path.join(manifestDir, '${TARGET.file}.manifest')
-	    env.AppendUnique( LINKFLAGS=['/MANIFEST', '/MANIFESTFILE:'+manifestfile] )
-	    env['LINKCOM'] = [env['LINKCOM'], 'mt.exe -nologo -manifest '+manifestfile+' -outputresource:$TARGET;1']
-	    env['SHLINKCOM'] = [env['SHLINKCOM'], 'mt.exe -nologo -manifest '+manifestfile+' -outputresource:$TARGET;2']
+        if manifestDir is not None:
+            # TODO add manifest as sideeffect() and clean() using an emitter 
+            manifestfile = os.path.join(manifestDir, '${TARGET.file}.manifest')
+            env.AppendUnique( LINKFLAGS=['/MANIFEST', '/MANIFESTFILE:'+manifestfile] )
+            env['LINKCOM'] = [env['LINKCOM'], 'mt.exe -nologo -manifest '+manifestfile+' -outputresource:$TARGET;1']
+            env['SHLINKCOM'] = [env['SHLINKCOM'], 'mt.exe -nologo -manifest '+manifestfile+' -outputresource:$TARGET;2']
 
 
     # TODO for MinGW compiler, use manifest:
@@ -120,9 +120,9 @@ def SetupEnv(env, runtime="default", console=False, exceptions=True, omitFP=True
     # - link with manifestDir/msvcrc.o, add as dependency
 
     else:
-	env.AppendUnique( CPPFLAGS=['-Wall', '-W', '-Wconversion'] )
-	if release == 'debug':
-	    env.AppendUnique( CPPFLAGS=['-g'] )
-	elif release == 'release':
-	    env.AppendUnique( CPPFLAGS=['-O3'] )
+        env.AppendUnique( CPPFLAGS=['-Wall', '-W', '-Wconversion'] )
+        if release == 'debug':
+            env.AppendUnique( CPPFLAGS=['-g'] )
+        elif release == 'release':
+            env.AppendUnique( CPPFLAGS=['-O3'] )
     

--- a/site_scons/conf/LatexSetup.py
+++ b/site_scons/conf/LatexSetup.py
@@ -18,38 +18,38 @@ def SetupEnv(env):
     
     latex = env['LATEX_PATH']
     if latex is not None:
-	env.PrependENVPath('PATH', latex)
-	env.Tool('tex')
-	env.Tool('gs')
-	env.Tool('latex')
-	env.Tool('dvipdf')
-	env.Tool('dvips')
-	env.Tool('pdflatex')
-	env.Tool('pdftex')
+        env.PrependENVPath('PATH', latex)
+        env.Tool('tex')
+        env.Tool('gs')
+        env.Tool('latex')
+        env.Tool('dvipdf')
+        env.Tool('dvips')
+        env.Tool('pdflatex')
+        env.Tool('pdftex')
 
     if UseLatexSync(env):
-	env['LATEXFLAGS'] = env['LATEXFLAGS'] + ' -synctex=1'
-	env['PDFLATEXFLAGS'] = env['PDFLATEXFLAGS'] + ' -synctex=1'
+        env['LATEXFLAGS'] = env['LATEXFLAGS'] + ' -synctex=1'
+        env['PDFLATEXFLAGS'] = env['PDFLATEXFLAGS'] + ' -synctex=1'
 
     pplatex = env.get('PPLATEX',None)
 
     if pplatex is None or pplatex == '':
-	return
+        return
 
     # TODO if latex tools are in a non-standard path, add -c <exe> -- to arguments, provide option to set latex path
 
     if pplatex == "auto":
-	if env.Detect(['pplatex','ppdflatex']):
-	    env['LATEX'] = 'pplatex'
-	    env['PDFLATEX'] = 'ppdflatex'
+        if env.Detect(['pplatex','ppdflatex']):
+            env['LATEX'] = 'pplatex'
+            env['PDFLATEX'] = 'ppdflatex'
 
     else:
-	env['LATEX'] = os.path.join(pplatex,'pplatex')
-	env['PDFLATEX'] = os.path.join(pplatex,'ppdflatex')
+        env['LATEX'] = os.path.join(pplatex,'pplatex')
+        env['PDFLATEX'] = os.path.join(pplatex,'ppdflatex')
 
     opts = env['PPLATEX_OPT']
 
     if opts != '':
-	env['LATEX'] = env['LATEX'] + ' ' + opts + ' -- '
-	env['PDFLATEX'] = env['PDFLATEX'] + ' ' + opts + ' -- '
+        env['LATEX'] = env['LATEX'] + ' ' + opts + ' -- '
+        env['PDFLATEX'] = env['PDFLATEX'] + ' ' + opts + ' -- '
 

--- a/site_scons/conf/MSVCSetup.py
+++ b/site_scons/conf/MSVCSetup.py
@@ -1,10 +1,11 @@
+from __future__ import print_function
 import os
 from envhelper import *
 from confighelper import *
 
 def AddVariables(vars):
     vars.Add( "MSVC_USE_SCRIPT", "Name of the vcvarsall.bat script to read to initialize the environment, or False to disable reading", 
-	True, None, ConvertStrBool )
+        True, None, ConvertStrBool )
     vars.Add( "MSVC_PATH", "MS Visual Studio installation path (set if autodetection fails)", GetOSEnv('VCINSTALLDIR') )
     vars.Add( "MSVC_IDE_PATH", "MSVC common installation path (set if autodetection fails)", GetOSEnv('DevEnvDir') )
     vars.Add( "WINSDK_PATH", "MS VC SDK installation path (set if autodetection fails)", GetOSEnv('WindowsSdkDir') )
@@ -16,35 +17,35 @@ def SetupEnv(env):
     msvc = env.get('MSVC_PATH','')
 
     if msvc == '' and not usescript:
-	print "MSVC_PATH not set. Please make sure that VCINSTALLDIR is set by running 'vcvarsall.bat'"
-	print "in your VC8 installation dir or set MSVC_PATH to scons."
-	return
+        print("MSVC_PATH not set. Please make sure that VCINSTALLDIR is set by running 'vcvarsall.bat'")
+        print("in your VC8 installation dir or set MSVC_PATH to scons.")
+        return
 
     winsdk = env.get('WINSDK_PATH','')
     if winsdk == '' and not usescript:
-	print "WINSDK_PATH not set. Please make sure that WindowsSdkDir is set by running 'vcvarsall.bat'"
-	print "in your VC8 installation dir or set WINSDK_PATH to scons."
-	return
+        print("WINSDK_PATH not set. Please make sure that WindowsSdkDir is set by running 'vcvarsall.bat'")
+        print("in your VC8 installation dir or set WINSDK_PATH to scons.")
+        return
     
     devenv = env.get('MSVC_IDE_PATH','')
 
     if env['TARGET_ARCH'] == 'amd64':
-	archDir = '/amd64'
-	sdkArchDir = '/x64'
+        archDir = '/amd64'
+        sdkArchDir = '/x64'
     else:
-	archDir = ''
-	sdkArchDir = ''
+        archDir = ''
+        sdkArchDir = ''
 
     if msvc != '':
-	env.AppendENVPath('LIB',     os.path.join(env["MSVC_PATH"],"lib"+archDir) )
-	env.AppendENVPath('LIBPATH', os.path.join(env["MSVC_PATH"],"lib"+archDir) )
-	env.AppendENVPath('INCLUDE', os.path.join(env['MSVC_PATH'],'include') )
-	env.AppendENVPath('PATH',    os.path.join(env['MSVC_PATH'],'bin'+archDir) )
+        env.AppendENVPath('LIB',     os.path.join(env["MSVC_PATH"],"lib"+archDir) )
+        env.AppendENVPath('LIBPATH', os.path.join(env["MSVC_PATH"],"lib"+archDir) )
+        env.AppendENVPath('INCLUDE', os.path.join(env['MSVC_PATH'],'include') )
+        env.AppendENVPath('PATH',    os.path.join(env['MSVC_PATH'],'bin'+archDir) )
 
     if winsdk != '':
-	env.AppendENVPath('LIB',     os.path.join(env["WINSDK_PATH"],"lib"+sdkArchDir) )
-	env.AppendENVPath('INCLUDE', os.path.join(env['WINSDK_PATH'],'include') )
-	env.AppendENVPath('PATH',    os.path.join(env['WINSDK_PATH'],'bin'+sdkArchDir) )
+        env.AppendENVPath('LIB',     os.path.join(env["WINSDK_PATH"],"lib"+sdkArchDir) )
+        env.AppendENVPath('INCLUDE', os.path.join(env['WINSDK_PATH'],'include') )
+        env.AppendENVPath('PATH',    os.path.join(env['WINSDK_PATH'],'bin'+sdkArchDir) )
 
     if devenv != '':
         env.AppendENVPath('PATH',    devenv)

--- a/site_scons/conf/OpenGLSetup.py
+++ b/site_scons/conf/OpenGLSetup.py
@@ -4,37 +4,35 @@ from SCons.Script import *
 
 def AddVariables(vars, glew=False):
     if glew:
-	vars.Add( PathVariable('GLEWPATH', 'Path under which GLEW is installed', None, PathVariable.PathAccept) ) 
+        vars.Add( PathVariable('GLEWPATH', 'Path under which GLEW is installed', None, PathVariable.PathAccept) ) 
 
 
 def SetupEnv(env, glu=False, glut=False, glew=False):
     """Setup OpenGL libraries """
 
     if glew:
-	glu = True
+        glu = True
 
     if env['PLATFORM'] == "win32":
-	env.Append( LIBS=['opengl32'] )
-	if glu:
-	    env.Append( LIBS=['glu32'] )
-	if glut:
-	    env.Append( LIBS=['glut32'] )
-	if glew:
-	    env.Append( LIBS=['glew32'] )
+        env.Append( LIBS=['opengl32'] )
+        if glu:
+            env.Append( LIBS=['glu32'] )
+        if glut:
+            env.Append( LIBS=['glut32'] )
+        if glew:
+            env.Append( LIBS=['glew32'] )
     else:
-	env.Append( LIBS=['GL'] )
-	if glu:
-	    env.Append( LIBS=['GLU'] )
-	if glut:
-	    env.Append( LIBS=['glut'] )
-	if glew:
-	    env.Append( LIBS=['GLEW'] )
+        env.Append( LIBS=['GL'] )
+        if glu:
+            env.Append( LIBS=['GLU'] )
+        if glut:
+            env.Append( LIBS=['glut'] )
+        if glew:
+            env.Append( LIBS=['GLEW'] )
 
     if glew:
-	glewpath = env.get('GLEWPATH',None)
+        glewpath = env.get('GLEWPATH',None)
 
-	if glewpath is not None:
-	    env.Append( CPPPATH=[os.path.join(glewpath,'include')] )
-	    env.Append( LIBPATH=[os.path.join(glewpath,'lib')] )
-	
-
+        if glewpath is not None:
+            env.Append( CPPPATH=[os.path.join(glewpath,'include')] )
+            env.Append( LIBPATH=[os.path.join(glewpath,'lib')] )

--- a/site_scons/conf/__init__.py
+++ b/site_scons/conf/__init__.py
@@ -1,9 +1,9 @@
-import MSVCSetup
-import SDLSetup
-import CUDASetup
-import OpenGLSetup
-import DSetup
-import LatexSetup
-import DiaSetup
-import GnuplotSetup
-import NotationSetup
+from . import MSVCSetup
+from . import SDLSetup
+from . import CUDASetup
+from . import OpenGLSetup
+from . import DSetup
+from . import LatexSetup
+from . import DiaSetup
+from . import GnuplotSetup
+from . import NotationSetup

--- a/site_scons/confighelper.py
+++ b/site_scons/confighelper.py
@@ -4,14 +4,14 @@ from SCons.Script import *
 
 def ConvertStrBool(value, env=None):
     if value is None:
-	return False
+        return False
 
     if SCons.Util.is_String(value):
-	if value == '' or value == 'False' or value == 'false':
-	    return False
-	if value == 'True' or value == 'true':
-	    return True
-	return value
+        if value == '' or value == 'False' or value == 'false':
+            return False
+        if value == 'True' or value == 'true':
+            return True
+        return value
 
     return value
 
@@ -22,9 +22,9 @@ def InitVariables(argname='--conffile', option='config', release=False):
     system = platform.system().lower()
     pfile = 'config-'+system+'.py'
     if system != '' and os.path.isfile(pfile):
-	default = pfile
+        default = pfile
     else:
-	default = 'config.py'
+        default = 'config.py'
     
     AddOption(argname, default=default,
           dest=option, type='string', nargs=1, action='store', metavar='FILE',
@@ -33,7 +33,7 @@ def InitVariables(argname='--conffile', option='config', release=False):
     vars = Variables(GetOption(option))
 
     if release:
-	vars.Add(EnumVariable('RELEASE', 'Set the release type', 'release', allowed_values=('release','debug')))
+        vars.Add(EnumVariable('RELEASE', 'Set the release type', 'release', allowed_values=('release','debug')))
 
     return vars
 
@@ -46,24 +46,24 @@ def CreateEnv(vars):
 
 def LoadReleaseFile(env, filename):
 
-    rfile = file( filename, "rU" )
+    rfile = open( filename, "rU" )
     for line in rfile:
-	line = line.strip()
-	if len(line) == 0:
-	    continue
-	if line[0] == "#":
-	    continue
-	sep = line.find('=')
-	if sep == -1:
-	    continue
-	name = line[:sep].strip()
-	value = line[sep+1:].strip()
+        line = line.strip()
+        if len(line) == 0:
+            continue
+        if line[0] == "#":
+            continue
+        sep = line.find('=')
+        if sep == -1:
+            continue
+        name = line[:sep].strip()
+        value = line[sep+1:].strip()
 
-	if name == 'VERSION':
-	    if env['RELEASE'] == 'debug':
-		value += "-debug"
+        if name == 'VERSION':
+            if env['RELEASE'] == 'debug':
+                value += "-debug"
 
-	if name in ( 'NAME', 'VERSION' ):
-	    env['RELEASE_'+name] = value
+        if name in ( 'NAME', 'VERSION' ):
+            env['RELEASE_'+name] = value
 
     rfile.close()

--- a/site_scons/envhelper.py
+++ b/site_scons/envhelper.py
@@ -4,32 +4,32 @@ from SCons.Script import *
 def GetArchBits(env):
     """Get the number of bits for the target architecture"""
     if env['TARGET_ARCH'] == "amd64" or env['TARGET_ARCH'] == "x86_64" or env['TARGET_ARCH'] == "ia64":
-	return "64"
+        return "64"
     return "32"
 
 def FindToolPath(program, default=None):
     """Get the path for a program from the OS environment."""
     file=WhereIs(program)
     if file is None:
-	return default
+        return default
     return os.path.dirname(file)
 
 def FindTool(program, default=None):
     """Get the path of a program binary from the OS environment."""
     file=WhereIs(program)
     if file is None:
-	return default
+        return default
     return file
 
 def GetOSEnv(name, default=None):
     """Get a variable from the OS environment."""
     try:
-	return os.environ[name]
+        return os.environ[name]
     except:
-	return default
+        return default
 
 def Dirname(dir):
     if dir is None:
-	return None
+        return None
     return os.path.dirname(dir)
 


### PR DESCRIPTION
Using SCons 3 means using Python 3, which is pickier about mixed tab
and space indenting and using the print() function instead of the print
statement. Also relative imports have changed.

Fix this by indenting with spaces only and using the print() function
(using "from __future__ import print_function"). Additionally, fix
relative imports.

Fixes issue #13.