### PR TITLE
Fix for Python 3.7

### DIFF
--- a/site_scons/confighelper.py
+++ b/site_scons/confighelper.py
@@ -45,8 +45,7 @@ def CreateEnv(vars):
     return env
 
 def LoadReleaseFile(env, filename):
-
-    rfile = open( filename, "rU" )
+    rfile = open( filename, "r" )
     for line in rfile:
         line = line.strip()
         if len(line) == 0:


### PR DESCRIPTION
Python 3.7 does not support mode rU
(= universal newlines mode, see https://docs.python.org/3.6/library/functions.html#open)

Without this fix, we get the following error with Python 3.11:

```
$ scons
scons: Reading SConscript files ...
ValueError: invalid mode: 'rU':
  File "[...]/git-projects/pplatex/SConstruct", line 15:
    LoadReleaseFile(env, 'RELEASE')
  File "[...]/git-projects/pplatex/site_scons/confighelper.py", line 49:
    rfile = open( filename, "rU" )
```