### PR TITLE
Fix crash when invoked as ppluatex

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <cstdio>
 #include <cstdlib>
+#include <cctype>
 
 #if defined( __WIN32__ ) || defined( _WIN32 )
 
@@ -37,6 +38,33 @@
 #include "latexoutputfilter.h"
 
 using namespace std;
+
+/**
+ * Reduce argv[0] to the bare name pplatex was invoked as, so that the LaTeX
+ * engine can be selected from it. Strips any directory prefix and, on Windows,
+ * a trailing executable suffix.
+ */
+static string programName(const char* argv0) {
+    string name(argv0);
+
+    size_t pos = name.find_last_of("/\\");
+    if ( pos != string::npos ) {
+	name = name.substr(pos+1);
+    }
+
+    static const string exe = ".exe";
+    if ( name.length() > exe.length() ) {
+	string tail = name.substr(name.length() - exe.length());
+	for (size_t i = 0; i < tail.length(); i++) {
+	    tail[i] = tolower(tail[i]);
+	}
+	if ( tail == exe ) {
+	    name = name.substr(0, name.length() - exe.length());
+	}
+    }
+
+    return name;
+}
 
 class ArgParser {
     public:
@@ -118,14 +146,14 @@ class ArgParser {
 	    int quietopt = 0;
 	    int bbopt = 0;
 
-	    string name(argv[0]);
+	    string name = programName(argv[0]);
 
-	    if ( name.compare(name.length()-7,7,"pplatex") == 0 ) {
-		program = "latex";
-	    } else if ( name.compare(name.length()-9,9,"ppdflatex") == 0 ) {
+	    if ( name == "ppdflatex" ) {
 		program = "pdflatex";
-            } else if ( name.compare(name.length()-8,8,"ppluatex") == 0 ) {
+	    } else if ( name == "ppluatex" ) {
 		program = "lualatex";
+	    } else if ( name == "pplatex" ) {
+		program = "latex";
 	    } else {
 		cerr << "Invalid name for application binary." << endl;
 		exit(2);


### PR DESCRIPTION
Invoking the binary as `ppluatex` has never worked: it aborts before doing anything.

```
$ ppluatex -i foo.log
libc++abi: terminating due to uncaught exception of type std::out_of_range: basic_string
```

The engine is selected by comparing suffixes of `argv[0]` at computed offsets, and the 9-character `ppdflatex` test runs before the 8-character `ppluatex` test. For the exactly-8-character name, `name.length()-9` underflows and `compare()` throws. This is presumably why the SCons build installs the `src/ppluatex` shell wrapper on POSIX rather than the binary itself.

The fix matches the basename against the full name instead of an offset-computed suffix, and strips a trailing `.exe` first so the Windows binaries also select an engine rather than rejecting their own name. An unrecognised name now prints "Invalid name for application binary" as intended instead of aborting.

Verified all four spellings: `pplatex` → latex, `ppdflatex` → pdflatex, `ppluatex` → lualatex, `ppluatex.exe` → lualatex.
