### PR TITLE
Fix parser bugs: colon truncation, file:line:error support, Tectonic filenames

### DIFF
--- a/src/latexoutputfilter.cpp
+++ b/src/latexoutputfilter.cpp
@@ -23,6 +23,7 @@
 #include <pcreposix.h>
 
 #include <cstdlib>
+#include <cctype>
 #include <string>
 #include <sstream>
 #include <iostream>
@@ -80,6 +81,33 @@ static bool startsWith(const string &str, const string &match) {
 
 static bool startsWith(const string &str, char c) {
     return str.length() > 0 && str[0] == c;
+}
+
+/**
+ * Does this look like a filename TeX would have opened? Used when the file
+ * cannot be confirmed on disk, which is the normal case for class and package
+ * files that live in the distribution rather than next to the document.
+ */
+static bool looksLikeFileName(const string &str) {
+    size_t dot = str.find_last_of('.');
+
+    if ( dot == string::npos || dot == 0 || dot + 1 == str.length() ) {
+	return false;
+    }
+
+    // A short alphanumeric extension, so that prose such as "size option"
+    // is not mistaken for a file.
+    if ( str.length() - dot - 1 > 4 ) {
+	return false;
+    }
+
+    for (size_t i = dot + 1; i < str.length(); i++) {
+	if ( !isalnum((unsigned char)str[i]) ) {
+	    return false;
+	}
+    }
+
+    return true;
 }
 
 static bool endsWith(const string &str, char c) {
@@ -283,7 +311,14 @@ void LatexOutputFilter::updateFileStackHeuristic(const string &strLine, short & 
 			}
 
 			//FIXME: improve these heuristics
-			if((isLastChar && (i < 78)) || nextIsTerminator == ')' || nextIsTerminator == '\t' || fileExists(strPartialFileName)) {
+			// A '(' that never yields a pushed name is still popped by its
+			// matching ')', which drains the stack and eventually discards
+			// the real source file. Engines that pack several opens onto
+			// one line, such as Tectonic, hit this constantly; pdflatex
+			// mostly escapes it by wrapping at 79 columns, so its names
+			// land at the end of a line and take the isLastChar path.
+			if((isLastChar && (i < 78)) || nextIsTerminator == ')' || nextIsTerminator == '\t'
+			   || fileExists(strPartialFileName) || looksLikeFileName(strPartialFileName)) {
 				m_stackFile.push(LOFStackItem(strPartialFileName));
 				// KILE_DEBUG() << "\tpushed (i = " << i << " length = " << strLine.length() << "): " << strPartialFileName << endl;
 				expectFileName = false;
@@ -347,7 +382,14 @@ void LatexOutputFilter::flushCurrentItem()
     }
     */
 
-    string sourceFile = (m_stackFile.empty()) ? source() : m_stackFile.top().file();
+    string sourceFile;
+    if ( !m_fileLineSource.empty() ) {
+	// file:line:error named the file; trust it over the paren heuristic
+	sourceFile = m_fileLineSource;
+	m_fileLineSource.clear();
+    } else {
+	sourceFile = (m_stackFile.empty()) ? source() : m_stackFile.top().file();
+    }
     m_currentItem.setSource(sourceFile);
 
     switch (nItemType) {
@@ -381,7 +423,7 @@ bool LatexOutputFilter::detectError(const string & strLine, short &dwCookie)
 
 	bool found = false, flush = false;
 
-	static Regex reLaTeXError("^(! )?(LaTeX|pdfTeX|Package|Class) ((.*) )?Error.*:(.*)", true);
+	static Regex reLaTeXError("^(! )?(LaTeX|pdfTeX|Package|Class) ((.*) )?Error[^:]*: ?(.*)$", true);
 	static Regex rePDFLaTeXError("^Error: pdflatex (.*)$", true);
 	static Regex reTeXError("^! (.*)\\.$");
 	static Regex reLineNumber("^l\\.([0-9]+)(.*)");
@@ -460,6 +502,37 @@ bool LatexOutputFilter::detectError(const string & strLine, short &dwCookie)
 	return found;
 }
 
+/**
+ * Errors in "file:line:error" style, produced by -file-line-error. The format
+ * states the file and the line outright, so this bypasses both the parenthesis
+ * heuristic that tracks the current file and the scan for a following "l.<n>"
+ * context line.
+ */
+bool LatexOutputFilter::detectFileLineError(const string & strLine, short & dwCookie)
+{
+	// The file part is greedy so that a drive letter or any other colon in
+	// the path stays with the filename; only the last ":<digits>: " counts.
+	static Regex reFileLineError("^(.+):([0-9]+): (.+)$");
+
+	if(!reFileLineError.match(strLine)) {
+		return false;
+	}
+
+	m_fileLineSource = reFileLineError.getMatch(strLine, 1);
+
+	m_currentItem.setType(itmError);
+	m_currentItem.setOutputLine(GetCurrentOutputLine());
+	m_currentItem.setSourceLine(parseInt(reFileLineError.getMatch(strLine, 2)));
+	m_currentItem.setMessage(reFileLineError.getMatch(strLine, 3));
+
+	// Everything needed is on this one line, so emit it rather than waiting
+	// for a line number that this format never prints.
+	dwCookie = Start;
+	flushCurrentItem();
+
+	return true;
+}
+
 bool LatexOutputFilter::detectWarning(const string & strLine, short &dwCookie)
 {
 	//KILE_DEBUG() << "==LatexOutputFilter::detectWarning(" << strLine.length() << ")================" << endl;
@@ -473,7 +546,7 @@ bool LatexOutputFilter::detectWarning(const string & strLine, short &dwCookie)
 	bool found = false, flush = false;
 	string warning;
 
-	static Regex reLaTeXWarning("^(! )?(LaTeX|pdfTeX|Package|Class) ((.*) )?Warning.*:(.*)$", true);
+	static Regex reLaTeXWarning("^(! )?(LaTeX|pdfTeX|Package|Class) ((.*) )?Warning[^:]*: ?(.*)$", true);
 	static Regex reNoFile("No file (.*)");
 	// FIXME can be removed when http://sourceforge.net/tracker/index.php?func=detail&aid=1772022&group_id=120000&atid=685683 has promoted to the users
 	static Regex reNoAsyFile("File .* does not exist.");
@@ -517,8 +590,19 @@ bool LatexOutputFilter::detectWarning(const string & strLine, short &dwCookie)
 
 	    //warning spans multiple lines, detect the end
 	    case Warning :
-		flush = detectLaTeXLineNumber(warning, dwCookie, strLine.length());
+	    {
+		// The line-number scan needs the text of this continuation
+		// line; it used to receive the empty `warning` local, so a
+		// warning that carries its "on input line N." on a later line
+		// never got a source line. Strip trailing spaces first, the
+		// end-of-line anchors cannot see past them.
+		string cont = strLine;
+		size_t end = cont.find_last_not_of(" \t");
+		cont = (end == string::npos) ? "" : cont.substr(0, end+1);
+
+		flush = detectLaTeXLineNumber(cont, dwCookie, strLine.length());
 		m_currentItem.addMessage(strLine, needsSpace());
+	    }
 		break;
 
 	    default:
@@ -542,7 +626,10 @@ bool LatexOutputFilter::detectLaTeXLineNumber(string & warning, short & dwCookie
 	//KILE_DEBUG() << "==LatexOutputFilter::detectLaTeXLineNumber(" << warning.length() << ")================" << endl;
 
 	static Regex reLaTeXLineNumber("(.*) on input line ([0-9]+)\\.$", true);
-	static Regex reInternationalLaTeXLineNumber("(.*)([0-9]+)\\.$", true);
+	// The greedy (.*) must not eat into the number: on a line wrapped
+	// mid-word such as "e 13." it left only the final digit in group 2,
+	// reporting line 3 for line 13.
+	static Regex reInternationalLaTeXLineNumber("(.*[^0-9])([0-9]+)\\.$", true);
 
 	if(reLaTeXLineNumber.match(warning)) {
 		//KILE_DEBUG() << "een" << endl;
@@ -672,7 +759,8 @@ short LatexOutputFilter::parseLine(const string & strLine, short dwCookie)
 
 	switch (dwCookie) {
 		case Start :
-			if(!(detectBadBox(strLine, dwCookie) || detectWarning(strLine, dwCookie) || detectError(strLine, dwCookie))) {
+			if(!(detectBadBox(strLine, dwCookie) || detectWarning(strLine, dwCookie)
+			  || detectError(strLine, dwCookie) || detectFileLineError(strLine, dwCookie))) {
 				updateFileStack(strLine, dwCookie);
 			}
 		break;
@@ -706,6 +794,7 @@ short LatexOutputFilter::parseLine(const string & strLine, short dwCookie)
 bool LatexOutputFilter::run(FILE *out)
 {
 	m_nErrors = m_nWarnings = m_nBadBoxes = m_nParens = 0;
+	m_fileLineSource.clear();
 	m_nLastLineLength = 0;
 	while (!m_stackFile.empty()) {
 	    m_stackFile.pop();

--- a/src/latexoutputfilter.h
+++ b/src/latexoutputfilter.h
@@ -84,12 +84,19 @@ class LatexOutputFilter : public OutputFilter
 	virtual short parseLine(const std::string & strLine, short dwCookie);
 
 	bool detectError(const std::string & strLine, short &dwCookie);
+	bool detectFileLineError(const std::string & strLine, short &dwCookie);
 	bool detectWarning(const std::string & strLine, short &dwCookie);
 	bool detectBadBox(const std::string & strLine, short &dwCookie);
 	bool detectLaTeXLineNumber(std::string & warning, short & dwCookie, size_t len);
 	bool detectBadBoxLineNumber(std::string & strLine, short & dwCookie, size_t len);
 
 	bool fileExists(const std::string & name);
+
+	/**
+	Source file named by a file:line:error message. Overrides the file stack
+	for the current item only, since that format states the file outright.
+	*/
+	std::string m_fileLineSource;
 
 	/** 
 	Check if we need to add a space when we append a message to the last line 

--- a/src/outputinfo.cpp
+++ b/src/outputinfo.cpp
@@ -81,11 +81,20 @@ LatexOutputInfo::LatexOutputInfo(const string& strSrcFile, int nSrcLine, int nOu
 {
 }
 
-void LatexOutputInfo::addMessage(const string& msg, bool addSpace) 
+void LatexOutputInfo::addMessage(const string& msg, bool addSpace)
 {
-    if (msg.empty() || 
-	msg == "Type  H <return>  for immediate help." ||
-	msg == "...") 
+    // Lines reach us with their trailing spaces intact, because the length of
+    // an untrimmed line is what tells the filter whether latex wrapped a word.
+    // Compare without them, or filler padded out to the width of the log slips
+    // through: "Type  H <return>..." carries none and was dropped, while the
+    // "..." continuation marker carries dozens and was not.
+    string text = msg;
+    size_t end = text.find_last_not_of(" \t");
+    text = (end == string::npos) ? "" : text.substr(0, end+1);
+
+    if (text.empty() ||
+	text == "Type  H <return>  for immediate help." ||
+	text == "...")
     {
 	return;
     }

--- a/test/error_colon.log
+++ b/test/error_colon.log
@@ -1,0 +1,20 @@
+This is pdfTeX, Version 3.14159265 (preloaded format=latex)
+entering extended mode
+**error_colon.tex
+(./error_colon.tex
+LaTeX2e <2014/05/01>
+
+! Package biblatex Error: File 'error_colon.bbl' not created: run biber.
+
+See the biblatex package documentation for explanation.
+Type  H <return>  for immediate help.
+l.12 \printbibliography
+
+! Class beamer Error: Overwriting theme: default is not allowed.
+
+l.20 \usetheme
+
+)
+Here is how much of TeX's memory you used:
+ 1 string out of 1
+Output written on error_colon.pdf (1 page).

--- a/test/expected/blitzaerror.txt
+++ b/test/expected/blitzaerror.txt
@@ -1,0 +1,23 @@
+** Warning in /usr/share/texmf/tex/latex/pgf/basiclayer/pgfbaseimage.sty, Line 13: 
+   (Package pgf) This package is obsolete and no longer needed on input line 13.
+
+** Warning in /usr/share/texmf/tex/latex/beamer/base/beamer.cls: 
+   (Package hyperref) Option `pdfpagelabels' is turned off because \thepage is undefined.
+
+** Warning in /home/stefan/Documents/Uni/Vorlesungen/TI Master/Distributed Algorithms for Wireless Networks/svn/tmp/ps/content.tex, Line 49: 
+   (Package hyperref) Token not allowed in a PDFDocEncoded string,
+   removing `\new@ifnextchar' on input line 49.
+
+** Warning in /home/stefan/Documents/Uni/Vorlesungen/TI Master/Distributed Algorithms for Wireless Networks/svn/tmp/ps/content.tex: 
+   No file presentation.nav.
+
+** BadBox  in /home/stefan/Documents/Uni/Vorlesungen/TI Master/Distributed Algorithms for Wireless Networks/svn/tmp/ps/content.tex, Line 204: 
+   Overfull \hbox (2.84398pt too wide) in paragraph
+
+** Error   in /home/stefan/Documents/Uni/Vorlesungen/TI Master/Distributed Algorithms for Wireless Networks/svn/tmp/ps/content.tex, Line 292: 
+   Undefined control sequence \Contradiction ->\blitza  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/Vorlesungen/TI Master/Distributed Algorithms for Wireless Networks/svn/tmp/ps/content.tex, Line 312: 
+   Undefined control sequence \Contradiction ->\blitza  \end{frame}
+
+Result: o) Errors: 2, Warnings: 4, BadBoxes: 1

--- a/test/expected/error_colon.txt
+++ b/test/expected/error_colon.txt
@@ -1,0 +1,9 @@
+** Error   in ./error_colon.tex, Line 12: 
+   (Package biblatex) File 'error_colon.bbl' not created: run biber.
+   See the biblatex package documentation for explanation.
+   \printbibliography
+
+** Error   in ./error_colon.tex, Line 20: 
+   (Class beamer) Overwriting theme: default is not allowed. \usetheme
+
+Result: o) Errors: 2, Warnings: 0, BadBoxes: 0

--- a/test/expected/lotsoferrors.txt
+++ b/test/expected/lotsoferrors.txt
@@ -1,0 +1,1191 @@
+** Warning in /usr/share/texmf/tex/latex/pgf/basiclayer/pgfbaseimage.sty, Line 13: 
+   (Package pgf) This package is obsolete and no longer needed on input line 13.
+
+** Warning in /usr/share/texmf/tex/latex/beamer/base/beamer.cls: 
+   (Package hyperref) Option `pdfpagelabels' is turned off because \thepage is undefined.
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 14: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \begin{document}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 14: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \begin{document}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 14: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \begin{document}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 14: 
+   Missing number, treated as zero <to be read again>  \hbox  \begin{document}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 14: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox 
+   \begin{document}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 14: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \begin{document}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 14: 
+   Missing number, treated as zero <to be read again>  } \begin{document}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 14: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \begin{document}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 14: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \begin{document}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 14: 
+   Missing number, treated as zero <to be read again>  \hbox  \begin{document}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 14: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox 
+   \begin{document}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 14: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \begin{document}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 14: 
+   Missing number, treated as zero <to be read again>  } \begin{document}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 14: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \begin{document}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 20: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 20: 
+   Missing number, treated as zero <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 20: 
+   Illegal unit of measure (pt inserted) <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 20: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 20: 
+   Missing number, treated as zero <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 20: 
+   Illegal unit of measure (pt inserted) <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 20: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 20: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 20: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 20: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 20: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 20: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** BadBox  in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex: 
+   Overfull \hbox (56.90549pt too wide) has occurred while \output is active
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 20: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 20: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 20: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 20: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 20: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 20: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 24: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 24: 
+   Missing number, treated as zero <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 24: 
+   Illegal unit of measure (pt inserted) <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 24: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 24: 
+   Missing number, treated as zero <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 24: 
+   Illegal unit of measure (pt inserted) <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 24: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 24: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 24: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 24: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 24: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 24: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** BadBox  in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex: 
+   Overfull \hbox (56.90549pt too wide) has occurred while \output is active
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 24: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 24: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 24: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 24: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 24: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 24: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 35: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 35: 
+   Missing number, treated as zero <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 35: 
+   Illegal unit of measure (pt inserted) <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 35: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 35: 
+   Missing number, treated as zero <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 35: 
+   Illegal unit of measure (pt inserted) <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 35: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 35: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 35: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 35: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 35: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 35: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** BadBox  in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex: 
+   Overfull \hbox (56.90549pt too wide) has occurred while \output is active
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 35: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 35: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 35: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 35: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 35: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 35: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 42: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 42: 
+   Missing number, treated as zero <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 42: 
+   Illegal unit of measure (pt inserted) <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 42: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 42: 
+   Missing number, treated as zero <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 42: 
+   Illegal unit of measure (pt inserted) <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 42: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 42: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 42: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 42: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 42: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 42: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** BadBox  in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex: 
+   Overfull \hbox (56.90549pt too wide) has occurred while \output is active
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 42: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 42: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 42: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 42: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 42: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 42: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 49: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 49: 
+   Missing number, treated as zero <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 49: 
+   Illegal unit of measure (pt inserted) <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 49: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 49: 
+   Missing number, treated as zero <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 49: 
+   Illegal unit of measure (pt inserted) <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 49: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 49: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 49: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 49: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 49: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 49: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** BadBox  in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex: 
+   Overfull \hbox (56.90549pt too wide) has occurred while \output is active
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 49: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 49: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 49: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 49: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 49: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 49: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Missing number, treated as zero <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Illegal unit of measure (pt inserted) <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Missing number, treated as zero <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Illegal unit of measure (pt inserted) <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** BadBox  in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex: 
+   Overfull \hbox (56.90549pt too wide) has occurred while \output is active
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Missing number, treated as zero <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Illegal unit of measure (pt inserted) <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Missing number, treated as zero <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Illegal unit of measure (pt inserted) <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** BadBox  in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex: 
+   Overfull \hbox (56.90549pt too wide) has occurred while \output is active
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 70: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Missing number, treated as zero <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Illegal unit of measure (pt inserted) <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Missing number, treated as zero <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Illegal unit of measure (pt inserted) <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** BadBox  in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex: 
+   Overfull \hbox (56.90549pt too wide) has occurred while \output is active
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Missing number, treated as zero <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Illegal unit of measure (pt inserted) <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Missing number, treated as zero <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Illegal unit of measure (pt inserted) <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** BadBox  in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex: 
+   Overfull \hbox (56.90549pt too wide) has occurred while \output is active
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 91: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** BadBox  in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex: 
+   Overfull \hbox (56.90549pt too wide) has occurred while \output is active
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** BadBox  in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex: 
+   Overfull \hbox (56.90549pt too wide) has occurred while \output is active
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** BadBox  in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex: 
+   Overfull \hbox (56.90549pt too wide) has occurred while \output is active
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** BadBox  in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex: 
+   Overfull \hbox (56.90549pt too wide) has occurred while \output is active
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** BadBox  in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex: 
+   Overfull \hbox (56.90549pt too wide) has occurred while \output is active
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** BadBox  in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex: 
+   Overfull \hbox (56.90549pt too wide) has occurred while \output is active
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** BadBox  in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex: 
+   Overfull \hbox (56.90549pt too wide) has occurred while \output is active
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 110: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Missing number, treated as zero <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Illegal unit of measure (pt inserted) <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Missing number, treated as zero <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Illegal unit of measure (pt inserted) <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** BadBox  in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex: 
+   Overfull \hbox (56.90549pt too wide) has occurred while \output is active
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Missing number, treated as zero <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Illegal unit of measure (pt inserted) <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Missing number, treated as zero <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Illegal unit of measure (pt inserted) <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** BadBox  in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex: 
+   Overfull \hbox (56.90549pt too wide) has occurred while \output is active
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Missing number, treated as zero <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Illegal unit of measure (pt inserted) <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Missing number, treated as zero <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Illegal unit of measure (pt inserted) <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** BadBox  in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex: 
+   Overfull \hbox (56.90549pt too wide) has occurred while \output is active
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 128: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 141: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 141: 
+   Missing number, treated as zero <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 141: 
+   Illegal unit of measure (pt inserted) <to be read again>  \box  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 141: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 141: 
+   Missing number, treated as zero <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 141: 
+   Illegal unit of measure (pt inserted) <to be read again>  { \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 141: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 141: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 141: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 141: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 141: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 141: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+** BadBox  in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex: 
+   Overfull \hbox (56.90549pt too wide) has occurred while \output is active
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 141: 
+   Undefined control sequence \Gm@lmargin ->\Geom@lmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 141: 
+   Missing number, treated as zero <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 141: 
+   Illegal unit of measure (pt inserted) <to be read again>  \hbox  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 141: 
+   Undefined control sequence \Gm@rmargin ->\Geom@rmargin  \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 141: 
+   Missing number, treated as zero <to be read again>  } \end{frame}
+
+** Error   in /home/stefan/Documents/Uni/DA/svn/thesis/presentations/final.tex, Line 141: 
+   Illegal unit of measure (pt inserted) <to be read again>  } \end{frame}
+
+Result: o) Errors: 374, Warnings: 2, BadBoxes: 20

--- a/test/expected/min.txt
+++ b/test/expected/min.txt
@@ -1,0 +1,3 @@
+** Error   in ./min.tex, Line 3: Undefined control sequence.
+
+Result: o) Errors: 1, Warnings: 0, BadBoxes: 0

--- a/test/expected/pagemarkers.txt
+++ b/test/expected/pagemarkers.txt
@@ -1,0 +1,3 @@
+** Error   in ./chapter.tex, Line 42: Undefined control sequence \nosuch
+
+Result: o) Errors: 1, Warnings: 0, BadBoxes: 0

--- a/test/expected/pgferror.txt
+++ b/test/expected/pgferror.txt
@@ -1,0 +1,28 @@
+** Warning in /usr/share/texmf/tex/latex/pgf/basiclayer/pgfbaseimage.sty, Line 13: 
+   (Package pgf) This package is obsolete and no longer needed on input line 13.
+
+** Warning in /usr/share/texmf/tex/latex/beamer/base/beamer.cls: 
+   (Package hyperref) Option `pdfpagelabels' is turned off because \thepage is undefined.
+
+** Warning in /home/stefan/Documents/Uni/Vorlesungen/TI Master/Distributed Algorithms for Wireless Networks/svn/tmp/ps/content.tex, Line 44: 
+   (Package hyperref) Token not allowed in a PDFDocEncoded string,
+   removing `\new@ifnextchar' on input line 44.
+
+** Warning in /home/stefan/Documents/Uni/Vorlesungen/TI Master/Distributed Algorithms for Wireless Networks/svn/tmp/ps/content.tex: 
+   No file presentation.nav.
+
+** Error   in /home/stefan/Documents/Uni/Vorlesungen/TI Master/Distributed Algorithms for Wireless Networks/svn/tmp/ps/content.tex, Line 195: 
+   (Package pgfkeys) I do not know the key '/tikz/important line' and I am 
+   going to ignore it. Perhaps you misspelled it.
+   See the pgfkeys package documentation for explanation.
+   \end{frame}
+
+** BadBox  in /home/stefan/Documents/Uni/Vorlesungen/TI Master/Distributed Algorithms for Wireless Networks/svn/tmp/ps/content.tex, Line 195: 
+   Overfull \hbox (12.64342pt too wide) in paragraph
+
+** Error   in /home/stefan/Documents/Uni/Vorlesungen/TI Master/Distributed Algorithms for Wireless Networks/svn/tmp/ps/presentation.aux, Line 195: 
+   (Package pgfkeys) I do not know the key going to ignore it. Perhaps you misspelled it.
+   See the pgfkeys package documentation for explanation.
+   \end{frame}
+
+Result: o) Errors: 2, Warnings: 4, BadBoxes: 1

--- a/test/expected/superseterror.txt
+++ b/test/expected/superseterror.txt
@@ -1,0 +1,27 @@
+** Warning in /usr/share/texmf/tex/latex/pgf/basiclayer/pgfbaseimage.sty, Line 13: 
+   (Package pgf) This package is obsolete and no longer needed on input line 13.
+
+** Warning in /usr/share/texmf/tex/latex/beamer/base/beamer.cls: 
+   (Package hyperref) Option `pdfpagelabels' is turned off because \thepage is undefined.
+
+** Warning in /home/stefan/Documents/Uni/Vorlesungen/TI Master/Distributed Algorithms for Wireless Networks/svn/tmp/ps/content.tex, Line 48: 
+   (Package hyperref) Token not allowed in a PDFDocEncoded string,
+   removing `\new@ifnextchar' on input line 48.
+
+** Warning in /home/stefan/Documents/Uni/Vorlesungen/TI Master/Distributed Algorithms for Wireless Networks/svn/tmp/ps/content.tex: 
+   No file presentation.nav.
+
+** BadBox  in /home/stefan/Documents/Uni/Vorlesungen/TI Master/Distributed Algorithms for Wireless Networks/svn/tmp/ps/content.tex, Line 203: 
+   Overfull \hbox (2.84398pt too wide) in paragraph
+
+** Warning in /home/stefan/Documents/Uni/Vorlesungen/TI Master/Distributed Algorithms for Wireless Networks/svn/tmp/ps/content.tex, Line 291: 
+   (LaTeX Font) Font shape `U/ulsy/m/n' in size <10.95> not available
+   size <10> substituted on input line 291.
+
+** Error   in /home/stefan/Documents/Uni/Vorlesungen/TI Master/Distributed Algorithms for Wireless Networks/svn/tmp/ps/content.tex, Line 355: 
+   Undefined control sequence <recently read> \superseteq  \end{frame}
+
+** Warning in /home/stefan/Documents/Uni/Vorlesungen/TI Master/Distributed Algorithms for Wireless Networks/svn/tmp/ps/content.tex: 
+   (LaTeX Font) Size substitutions with differences up to 0.95pt have occurred.
+
+Result: o) Errors: 1, Warnings: 6, BadBoxes: 1

--- a/test/expected/tectonic.txt
+++ b/test/expected/tectonic.txt
@@ -1,0 +1,5 @@
+** Warning in test.tex: No file test.aux.
+
+** Error   in test.tex, Line 10: Missing $ inserted <inserted text>  $
+
+Result: o) Errors: 1, Warnings: 1, BadBoxes: 0

--- a/test/expected/warning_colon.txt
+++ b/test/expected/warning_colon.txt
@@ -1,0 +1,10 @@
+** Warning in ./warning_colon.tex, Line 7: 
+   (Package hyperref) Option `pdfpagelabels': turned off on input line 7.
+
+** Warning in ./warning_colon.tex, Line 11: 
+   (Class beamer) Overwriting theme: default on input line 11.
+
+** Warning in ./warning_colon.tex, Line 15: 
+   Reference `sec:intro' on page 1 undefined on input line 15.
+
+Result: o) Errors: 0, Warnings: 3, BadBoxes: 0

--- a/test/pagemarkers.log
+++ b/test/pagemarkers.log
@@ -1,0 +1,9 @@
+This is pdfTeX, Version 3.14159265 (preloaded format=latex)
+**doc.tex
+(./doc.tex
+LaTeX2e <2014/05/01>
+(./chapter.tex [12] [13]
+! Undefined control sequence.
+l.42 \nosuch
+)
+)

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+#
+# Run every fixture in test/ through pplatex and compare against the expected
+# output committed alongside it.
+#
+#   test/run.sh [<path-to-pplatex>]     check against test/expected/
+#   test/run.sh --update [<pplatex>]    rewrite test/expected/ from the binary
+#
+# Regenerating is expected when a change is meant to alter output. Read the
+# resulting diff line by line before committing it: every changed line is either
+# the improvement you intended or a regression.
+
+set -u
+
+testdir=$(cd "$(dirname "$0")" && pwd)
+expected="$testdir/expected"
+
+update=false
+if [ "${1:-}" = "--update" ]; then
+    update=true
+    shift
+fi
+
+# Default to the build directory used by the README, then fall back to PATH.
+pplatex=${1:-}
+if [ -z "$pplatex" ]; then
+    if [ -x "$testdir/../build/src/pplatex" ]; then
+	pplatex="$testdir/../build/src/pplatex"
+    else
+	pplatex=$(command -v pplatex)
+    fi
+fi
+
+if [ ! -x "$pplatex" ]; then
+    echo "no pplatex binary found; build one or pass a path" >&2
+    exit 2
+fi
+
+mkdir -p "$expected"
+
+failed=0
+checked=0
+
+for log in "$testdir"/*.log; do
+    name=$(basename "$log" .log)
+    want="$expected/$name.txt"
+
+    # pplatex exits non-zero when the log contained errors, which is not a
+    # failure of the run itself.
+    got=$("$pplatex" -i "$log" 2>&1)
+
+    if $update; then
+	printf '%s\n' "$got" > "$want"
+	echo "updated $name"
+	continue
+    fi
+
+    checked=$((checked + 1))
+
+    if [ ! -f "$want" ]; then
+	echo "FAIL $name: no expected output, run '$0 --update'"
+	failed=$((failed + 1))
+    elif ! printf '%s\n' "$got" | diff -u "$want" - > /tmp/pplatex-$name.diff; then
+	echo "FAIL $name:"
+	sed 's/^/    /' /tmp/pplatex-$name.diff
+	failed=$((failed + 1))
+    else
+	echo "ok   $name"
+    fi
+done
+
+$update && exit 0
+
+echo
+if [ $failed -eq 0 ]; then
+    echo "$checked fixtures, all matching"
+else
+    echo "$checked fixtures, $failed failing"
+fi
+
+exit $((failed > 0))

--- a/test/tectonic.log
+++ b/test/tectonic.log
@@ -1,0 +1,396 @@
+**
+(test.tex
+LaTeX2e <2021-11-15> patch level 1
+L3 programming layer <2022-02-24> (article.cls
+Document Class: article 2021/10/04 v1.4n Standard LaTeX document class
+(size10.clo
+File: size10.clo 2021/10/04 v1.4n Standard LaTeX file (size option)
+)
+\c@part=\count181
+\c@section=\count182
+\c@subsection=\count183
+\c@subsubsection=\count184
+\c@paragraph=\count185
+\c@subparagraph=\count186
+\c@figure=\count187
+\c@table=\count188
+\abovecaptionskip=\skip47
+\belowcaptionskip=\skip48
+\bibindent=\dimen138
+) (tikz.sty (pgf.sty (pgfrcs.sty (pgfutil-common.tex
+\pgfutil@everybye=\toks16
+\pgfutil@tempdima=\dimen139
+\pgfutil@tempdimb=\dimen140
+
+(pgfutil-common-lists.tex)) (pgfutil-latex.def
+\pgfutil@abb=\box50
+) (pgfrcs.code.tex
+(pgf.revision.tex)
+Package: pgfrcs 2021/05/15 v3.1.9a (3.1.9a)
+))
+Package: pgf 2021/05/15 v3.1.9a (3.1.9a)
+ (pgfcore.sty (graphicx.sty
+Package: graphicx 2021/09/16 v1.2d Enhanced LaTeX Graphics (DPC,SPQR)
+ (keyval.sty
+Package: keyval 2014/10/28 v1.15 key=value parser (DPC)
+\KV@toks@=\toks17
+) (graphics.sty
+Package: graphics 2021/03/04 v1.4d Standard LaTeX Graphics (DPC,SPQR)
+
+(trig.sty
+Package: trig 2021/08/11 v1.11 sin cos tan (DPC)
+) (graphics.cfg
+File: graphics.cfg 2016/06/04 v1.11 sample graphics configuration
+)
+Package graphics Info: Driver file: xetex.def on input line 107.
+ (xetex.def
+File: xetex.def 2021/03/18 v5.0k Graphics/color driver for xetex
+))
+\Gin@req@height=\dimen141
+\Gin@req@width=\dimen142
+) (pgfsys.sty (pgfsys.code.tex
+Package: pgfsys 2021/05/15 v3.1.9a (3.1.9a)
+
+(pgfkeys.code.tex
+\pgfkeys@pathtoks=\toks18
+\pgfkeys@temptoks=\toks19
+ (pgfkeysfiltered.code.tex
+\pgfkeys@tmptoks=\toks20
+))
+\pgf@x=\dimen143
+\pgf@y=\dimen144
+\pgf@xa=\dimen145
+\pgf@ya=\dimen146
+\pgf@xb=\dimen147
+\pgf@yb=\dimen148
+\pgf@xc=\dimen149
+\pgf@yc=\dimen150
+\pgf@xd=\dimen151
+\pgf@yd=\dimen152
+\w@pgf@writea=\write3
+\r@pgf@reada=\read2
+\c@pgf@counta=\count189
+\c@pgf@countb=\count190
+\c@pgf@countc=\count191
+\c@pgf@countd=\count192
+\t@pgf@toka=\toks21
+\t@pgf@tokb=\toks22
+\t@pgf@tokc=\toks23
+\pgf@sys@id@count=\count193
+ (pgf.cfg
+File: pgf.cfg 2021/05/15 v3.1.9a (3.1.9a)
+)
+Driver file for pgf: pgfsys-xetex.def
+ (pgfsys-xetex.def
+File: pgfsys-xetex.def 2021/05/15 v3.1.9a (3.1.9a)
+
+(pgfsys-dvipdfmx.def
+File: pgfsys-dvipdfmx.def 2021/05/15 v3.1.9a (3.1.9a)
+ (pgfsys-common-pdf.def
+File: pgfsys-common-pdf.def 2021/05/15 v3.1.9a (3.1.9a)
+)
+\pgfsys@objnum=\count194
+))) (pgfsyssoftpath.code.tex
+File: pgfsyssoftpath.code.tex 2021/05/15 v3.1.9a (3.1.9a)
+\pgfsyssoftpath@smallbuffer@items=\count195
+\pgfsyssoftpath@bigbuffer@items=\count196
+)
+(pgfsysprotocol.code.tex
+File: pgfsysprotocol.code.tex 2021/05/15 v3.1.9a (3.1.9a)
+)) (xcolor.sty
+Package: xcolor 2021/10/31 v2.13 LaTeX color extensions (UK)
+ (color.cfg
+File: color.cfg 2016/01/02 v1.6 sample color configuration
+)
+Package xcolor Info: Driver file: xetex.def on input line 227.
+Package xcolor Info: Model `cmy' substituted by `cmy0' on input line 1352.
+Package xcolor Info: Model `RGB' extended on input line 1368.
+Package xcolor Info: Model `HTML' substituted by `rgb' on input line 1370.
+Package xcolor Info: Model `Hsb' substituted by `hsb' on input line 1371.
+Package xcolor Info: Model `tHsb' substituted by `hsb' on input line 1372.
+Package xcolor Info: Model `HSB' substituted by `hsb' on input line 1373.
+Package xcolor Info: Model `Gray' substituted by `gray' on input line 1374.
+Package xcolor Info: Model `wave' substituted by `hsb' on input line 1375.
+) (pgfcore.code.tex
+Package: pgfcore 2021/05/15 v3.1.9a (3.1.9a)
+
+(pgfmath.code.tex (pgfmathcalc.code.tex (pgfmathutil.code.tex)
+(pgfmathparser.code.tex
+\pgfmath@dimen=\dimen153
+\pgfmath@count=\count197
+\pgfmath@box=\box51
+\pgfmath@toks=\toks24
+\pgfmath@stack@operand=\toks25
+\pgfmath@stack@operation=\toks26
+) (pgfmathfunctions.code.tex
+(pgfmathfunctions.basic.code.tex) (pgfmathfunctions.trigonometric.code.tex)
+(pgfmathfunctions.random.code.tex) (pgfmathfunctions.comparison.code.tex)
+(pgfmathfunctions.base.code.tex) (pgfmathfunctions.round.code.tex)
+(pgfmathfunctions.misc.code.tex) (pgfmathfunctions.integerarithmetics.code.tex)
+)) (pgfmathfloat.code.tex
+\c@pgfmathroundto@lastzeros=\count198
+)) (pgfint.code.tex) (pgfcorepoints.code.tex
+File: pgfcorepoints.code.tex 2021/05/15 v3.1.9a (3.1.9a)
+\pgf@picminx=\dimen154
+\pgf@picmaxx=\dimen155
+\pgf@picminy=\dimen156
+\pgf@picmaxy=\dimen157
+\pgf@pathminx=\dimen158
+\pgf@pathmaxx=\dimen159
+\pgf@pathminy=\dimen160
+\pgf@pathmaxy=\dimen161
+\pgf@xx=\dimen162
+\pgf@xy=\dimen163
+\pgf@yx=\dimen164
+\pgf@yy=\dimen165
+\pgf@zx=\dimen166
+\pgf@zy=\dimen167
+)
+(pgfcorepathconstruct.code.tex
+File: pgfcorepathconstruct.code.tex 2021/05/15 v3.1.9a (3.1.9a)
+\pgf@path@lastx=\dimen168
+\pgf@path@lasty=\dimen169
+) (pgfcorepathusage.code.tex
+File: pgfcorepathusage.code.tex 2021/05/15 v3.1.9a (3.1.9a)
+\pgf@shorten@end@additional=\dimen170
+\pgf@shorten@start@additional=\dimen171
+)
+(pgfcorescopes.code.tex
+File: pgfcorescopes.code.tex 2021/05/15 v3.1.9a (3.1.9a)
+\pgfpic=\box52
+\pgf@hbox=\box53
+\pgf@layerbox@main=\box54
+\pgf@picture@serial@count=\count199
+) (pgfcoregraphicstate.code.tex
+File: pgfcoregraphicstate.code.tex 2021/05/15 v3.1.9a (3.1.9a)
+\pgflinewidth=\dimen172
+)
+(pgfcoretransformations.code.tex
+File: pgfcoretransformations.code.tex 2021/05/15 v3.1.9a (3.1.9a)
+\pgf@pt@x=\dimen173
+\pgf@pt@y=\dimen174
+\pgf@pt@temp=\dimen175
+) (pgfcorequick.code.tex
+File: pgfcorequick.code.tex 2021/05/15 v3.1.9a (3.1.9a)
+)
+(pgfcoreobjects.code.tex
+File: pgfcoreobjects.code.tex 2021/05/15 v3.1.9a (3.1.9a)
+) (pgfcorepathprocessing.code.tex
+File: pgfcorepathprocessing.code.tex 2021/05/15 v3.1.9a (3.1.9a)
+)
+(pgfcorearrows.code.tex
+File: pgfcorearrows.code.tex 2021/05/15 v3.1.9a (3.1.9a)
+\pgfarrowsep=\dimen176
+) (pgfcoreshade.code.tex
+File: pgfcoreshade.code.tex 2021/05/15 v3.1.9a (3.1.9a)
+\pgf@max=\dimen177
+\pgf@sys@shading@range@num=\count266
+\pgf@shadingcount=\count267
+) (pgfcoreimage.code.tex
+File: pgfcoreimage.code.tex 2021/05/15 v3.1.9a (3.1.9a)
+
+(pgfcoreexternal.code.tex
+File: pgfcoreexternal.code.tex 2021/05/15 v3.1.9a (3.1.9a)
+\pgfexternal@startupbox=\box55
+)) (pgfcorelayers.code.tex
+File: pgfcorelayers.code.tex 2021/05/15 v3.1.9a (3.1.9a)
+)
+(pgfcoretransparency.code.tex
+File: pgfcoretransparency.code.tex 2021/05/15 v3.1.9a (3.1.9a)
+) (pgfcorepatterns.code.tex
+File: pgfcorepatterns.code.tex 2021/05/15 v3.1.9a (3.1.9a)
+) (pgfcorerdf.code.tex
+File: pgfcorerdf.code.tex 2021/05/15 v3.1.9a (3.1.9a)
+))) (pgfmoduleshapes.code.tex
+File: pgfmoduleshapes.code.tex 2021/05/15 v3.1.9a (3.1.9a)
+\pgfnodeparttextbox=\box56
+) (pgfmoduleplot.code.tex
+File: pgfmoduleplot.code.tex 2021/05/15 v3.1.9a (3.1.9a)
+)
+(pgfcomp-version-0-65.sty
+Package: pgfcomp-version-0-65 2021/05/15 v3.1.9a (3.1.9a)
+\pgf@nodesepstart=\dimen178
+\pgf@nodesepend=\dimen179
+) (pgfcomp-version-1-18.sty
+Package: pgfcomp-version-1-18 2021/05/15 v3.1.9a (3.1.9a)
+)) (pgffor.sty (pgfkeys.sty (pgfkeys.code.tex)) (pgfmath.sty (pgfmath.code.tex)
+) (pgffor.code.tex
+Package: pgffor 2021/05/15 v3.1.9a (3.1.9a)
+
+(pgfmath.code.tex)
+\pgffor@iter=\dimen180
+\pgffor@skip=\dimen181
+\pgffor@stack=\toks27
+\pgffor@toks=\toks28
+)) (tikz.code.tex
+Package: tikz 2021/05/15 v3.1.9a (3.1.9a)
+ (pgflibraryplothandlers.code.tex
+File: pgflibraryplothandlers.code.tex 2021/05/15 v3.1.9a (3.1.9a)
+\pgf@plot@mark@count=\count268
+\pgfplotmarksize=\dimen182
+)
+\tikz@lastx=\dimen183
+\tikz@lasty=\dimen184
+\tikz@lastxsaved=\dimen185
+\tikz@lastysaved=\dimen186
+\tikz@lastmovetox=\dimen187
+\tikz@lastmovetoy=\dimen188
+\tikzleveldistance=\dimen189
+\tikzsiblingdistance=\dimen190
+\tikz@figbox=\box57
+\tikz@figbox@bg=\box58
+\tikz@tempbox=\box59
+\tikz@tempbox@bg=\box60
+\tikztreelevel=\count269
+\tikznumberofchildren=\count270
+\tikznumberofcurrentchild=\count271
+\tikz@fig@count=\count272
+
+(pgfmodulematrix.code.tex
+File: pgfmodulematrix.code.tex 2021/05/15 v3.1.9a (3.1.9a)
+\pgfmatrixcurrentrow=\count273
+\pgfmatrixcurrentcolumn=\count274
+\pgf@matrix@numberofcolumns=\count275
+)
+\tikz@expandcount=\count276
+ (tikzlibrarytopaths.code.tex
+File: tikzlibrarytopaths.code.tex 2021/05/15 v3.1.9a (3.1.9a)
+))) (amsmath.sty
+Package: amsmath 2021/10/15 v2.17l AMS math features
+\@mathmargin=\skip49
+
+For additional information on amsmath, use the `?' option.
+(amstext.sty
+Package: amstext 2021/08/26 v2.01 AMS text
+ (amsgen.sty
+File: amsgen.sty 1999/11/30 v2.0 generic functions
+\@emptytoks=\toks29
+\ex@=\dimen191
+)) (amsbsy.sty
+Package: amsbsy 1999/11/29 v1.2d Bold Symbols
+\pmbraise@=\dimen192
+) (amsopn.sty
+Package: amsopn 2021/08/26 v2.02 operator names
+)
+\inf@bad=\count277
+LaTeX Info: Redefining \frac on input line 234.
+\uproot@=\count278
+\leftroot@=\count279
+LaTeX Info: Redefining \overline on input line 399.
+\classnum@=\count280
+\DOTSCASE@=\count281
+LaTeX Info: Redefining \ldots on input line 496.
+LaTeX Info: Redefining \dots on input line 499.
+LaTeX Info: Redefining \cdots on input line 620.
+\Mathstrutbox@=\box61
+\strutbox@=\box62
+\big@size=\dimen193
+LaTeX Font Info:    Redeclaring font encoding OML on input line 743.
+LaTeX Font Info:    Redeclaring font encoding OMS on input line 744.
+\macc@depth=\count282
+\c@MaxMatrixCols=\count283
+\dotsspace@=\muskip16
+\c@parentequation=\count284
+\dspbrk@lvl=\count285
+\tag@help=\toks30
+\row@=\count286
+\column@=\count287
+\maxfields@=\count288
+\andhelp@=\toks31
+\eqnshift@=\dimen194
+\alignsep@=\dimen195
+\tagshift@=\dimen196
+\tagwidth@=\dimen197
+\totwidth@=\dimen198
+\lineht@=\dimen199
+\@envbody=\toks32
+\multlinegap=\skip50
+\multlinetaggap=\skip51
+\mathdisplay@stack=\toks33
+LaTeX Info: Redefining \[ on input line 2938.
+LaTeX Info: Redefining \] on input line 2939.
+) (mathtools.sty
+Package: mathtools 2022/02/07 v1.28a mathematical typesetting tools
+ (calc.sty
+Package: calc 2017/05/25 v4.3 Infix arithmetic (KKT,FJ)
+\calc@Acount=\count289
+\calc@Bcount=\count290
+\calc@Adimen=\dimen256
+\calc@Bdimen=\dimen257
+\calc@Askip=\skip52
+\calc@Bskip=\skip53
+LaTeX Info: Redefining \setlength on input line 80.
+LaTeX Info: Redefining \addtolength on input line 81.
+\calc@Ccount=\count291
+\calc@Cskip=\skip54
+) (mhsetup.sty
+Package: mhsetup 2021/03/18 v1.4 programming setup (MH)
+)
+\g_MT_multlinerow_int=\count292
+\l_MT_multwidth_dim=\dimen258
+\origjot=\skip55
+\l_MT_shortvdotswithinadjustabove_dim=\dimen259
+\l_MT_shortvdotswithinadjustbelow_dim=\dimen260
+\l_MT_above_intertext_sep=\dimen261
+\l_MT_below_intertext_sep=\dimen262
+\l_MT_above_shortintertext_sep=\dimen263
+\l_MT_below_shortintertext_sep=\dimen264
+\xmathstrut@box=\box63
+\xmathstrut@dim=\dimen265
+) (tikzlibraryhobby.code.tex (pgflibraryhobby.code.tex
+(hobby.code.tex (expl3.sty
+Package: expl3 2022-02-24 L3 programming layer (loader) 
+ (l3backend-xetex.def
+File: l3backend-xetex.def 2022-02-07 L3 backend support: XeTeX
+\c__kernel_sys_dvipdfmx_version_int=\count293
+\l__color_backend_stack_int=\count294
+\g__color_backend_stack_int=\count295
+\g__graphics_track_int=\count296
+\l__pdf_internal_box=\box64
+\g__pdf_backend_object_int=\count297
+\g__pdf_backend_annotation_int=\count298
+\g__pdf_backend_link_int=\count299
+)) (xparse.sty
+Package: xparse 2022-01-12 L3 Experimental document command parser
+) (pml3array.sty
+\l_array_base_int=\count300
+\l_array_top_int=\count301
+\l_array_tmp_int=\count302
+\g_array_base_int=\count303
+)
+\l_hobby_npoints_int=\count304
+\l_hobby_draw_int=\count305
+))) (tikzlibrarycalc.code.tex
+File: tikzlibrarycalc.code.tex 2021/05/15 v3.1.9a (3.1.9a)
+)
+No file test.aux.
+\openout1 = `test.aux'.
+
+LaTeX Font Info:    Checking defaults for OML/cmm/m/it on input line 7.
+LaTeX Font Info:    ... okay on input line 7.
+LaTeX Font Info:    Checking defaults for OMS/cmsy/m/n on input line 7.
+LaTeX Font Info:    ... okay on input line 7.
+LaTeX Font Info:    Checking defaults for OT1/cmr/m/n on input line 7.
+LaTeX Font Info:    ... okay on input line 7.
+LaTeX Font Info:    Checking defaults for T1/cmr/m/n on input line 7.
+LaTeX Font Info:    ... okay on input line 7.
+LaTeX Font Info:    Checking defaults for TS1/cmr/m/n on input line 7.
+LaTeX Font Info:    Trying to load font information for TS1+cmr on input line 7
+.
+(ts1cmr.fd
+File: ts1cmr.fd 2019/12/16 v2.5j Standard LaTeX font definitions
+)
+LaTeX Font Info:    ... okay on input line 7.
+LaTeX Font Info:    Checking defaults for TU/lmr/m/n on input line 7.
+LaTeX Font Info:    ... okay on input line 7.
+LaTeX Font Info:    Checking defaults for OMX/cmex/m/n on input line 7.
+LaTeX Font Info:    ... okay on input line 7.
+LaTeX Font Info:    Checking defaults for U/cmr/m/n on input line 7.
+LaTeX Font Info:    ... okay on input line 7.
+
+! Missing $ inserted.
+<inserted text> 
+                $
+l.10 
+     
+No pages of output.

--- a/test/warning_colon.log
+++ b/test/warning_colon.log
@@ -1,0 +1,16 @@
+This is pdfTeX, Version 3.14159265-2.6-1.40.15 (preloaded format=latex)
+entering extended mode
+**warning_colon.tex
+(./warning_colon.tex
+LaTeX2e <2014/05/01>
+
+Package hyperref Warning: Option `pdfpagelabels': turned off on input line 7.
+
+Class beamer Warning: Overwriting theme: default on input line 11.
+
+LaTeX Warning: Reference `sec:intro' on page 1 undefined on input line 15.
+
+)
+Here is how much of TeX's memory you used:
+ 1 string out of 1
+Output written on warning_colon.pdf (1 page).


### PR DESCRIPTION
Five parser fixes, plus a fixture runner so the behavior changes are reviewable rather than asserted. Fixes #2, fixes #21, supersedes #18 and #19.

**Test harness first.** `test/run.sh` feeds each `test/*.log` through pplatex and diffs against `test/expected/<name>.txt` (`--update` regenerates). The expected files are committed, so each fix shows up as a reviewable diff. Four fixtures added for cases nothing covered.

**1. Errors and warnings lost text after their first colon.** Both patterns read `.*:(.*)` and the greedy `.*` runs to the *last* colon. Undefined-reference warnings and package errors quoting a filename or key always contain a second colon:

```
before:  intro' on page 1 undefined on input line 15.
after:   Reference `sec:intro' on page 1 undefined on input line 15.
```

Same fix as #19, extended to the error pattern, with the space after the colon optional so an empty message is not dropped.

**2. `file:line:error` logs parsed as nothing** (#2, open since 2013). With `-file-line-error`, errors read `./min.tex:3: Undefined control sequence.` and no pattern matched; `test/min.log` reported zero errors. The new detector takes file and line straight off the line and emits immediately, since this format never prints the `l.<n>` the normal path waits for.

**3. Errors from Tectonic had no filename** (#21). The paren heuristic pushes a filename only once it is fairly sure it has one, but pops on every `)`. A `(` that fails to push is still popped, so the stack drains — in the log from #21 the source file is discarded 21 lines in, after which every error reports no file. The trigger is several opens on one line:

```
) (tikz.sty (pgf.sty (pgfrcs.sty (pgfutil-common.tex
```

Only the last is pushed; the rest are followed by a space and fall through to `fileExists()`, which fails for distribution files that don't sit next to the document. pdflatex mostly escapes this by wrapping at 79 columns so names land at end-of-line. A candidate with a short alphanumeric extension is now accepted when it can't be confirmed on disk; prose like `size option` is still rejected. This also covers #18's page-marker case (`./chapter.tex [12] [13]` glued into the filename), verified by `test/pagemarkers.log`.

**4. Filler leaked into messages.** `addMessage()` compares lines against literals, but lines keep their trailing spaces (their untrimmed length is how wrapped words are detected), so the `...` marker padded to the log width never equalled `"..."`. The comparison is now right-trimmed.

**5. Multi-line warnings never got a line number.** The Warning-state branch passed an always-empty local to the line-number scan. It now scans the continuation line itself. This exposed a second bug in the wrapped-line fallback `(.*)([0-9]+)\.$`: the greedy group eats into the number, reporting Line 3 for a line wrapped as `...on input lin` / `e 13.`.

The existing fixtures change only in the intended ways: messages keep their text past a colon, `...` filler disappears, and eight warning headers gain `, Line N` — each N cross-checked against the number stated in its own message text.

Independent of #30: this branch builds against PCRE1 as-is.
